### PR TITLE
chore: add troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ More info can be found in [GitLab's doc](https://docs.gitlab.com/ee/topics/build
 
 ## Troubleshooting
 
+### Shallow repository
+
 If you encounter the error
 
 > Failed to push your source code because your repository is shallow and therefore cannot be pushed to the Clever Cloud remote
@@ -37,3 +39,25 @@ By default, GitLab uses a limited shallow clone as referenced here: <https://git
 Solution is to make sure one has a full copy of the repository.  
 To do so, in GitLab, go to `Settings` > `CI/CD` > `General pipelines` and scroll to the `Git strategy` section.  
 There either choose `git clone` to have a full clone of the repository or use `git fetch` but set `Git shallow clone` to `0` to make sure you get the full history
+
+### Application not found
+
+If, when running the commmand 
+
+```bash
+clever link ${APP_ID}
+```
+
+You get the message
+
+```bash
+[ERROR] Application not found
+```
+
+This may mean you need to specify the organization aswell
+
+```bash
+clever link ${APP_ID} --org ${ORG_ID}
+````
+
+**Note**: The `ORG_ID`, or Organization ID, can be found in the upper right corner of your Clever Cloud Console

--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ You need to set some variables in order to be able to use clever-tools in GitLab
 The rest of variables in this script are implicit in GitLab.
 
 More info can be found in [GitLab's doc](https://docs.gitlab.com/ee/topics/build_your_application.html)
+
+## Troubleshooting
+
+If you encounter the error
+
+> Failed to push your source code because your repository is shallow and therefore cannot be pushed to the Clever Cloud remote
+
+This means, GitLab make a [shallow clone](https://git-scm.com/docs/shallow) of the repository for the CI.
+This basically means the repository has an incomplete history.
+
+By default, GitLab uses a limited shallow clone as referenced here: <https://gitlab.com/gitlab-org/gitlab/-/issues/350100>
+
+Solution is to make sure one has a full copy of the repository.  
+To do so, in GitLab, go to `Settings` > `CI/CD` > `General pipelines` and scroll to the `Git strategy` section.  
+There either choose `git clone` to have a full clone of the repository or use `git fetch` but set `Git shallow clone` to `0` to make sure you get the full history


### PR DESCRIPTION
Added troubleshooting info about `Failed to push your source code because your repository is shallow and therefore cannot be pushed to the Clever Cloud remote` error message on GitLab  
This section explains how to setup GitLab to avoid this issue

And added troubleshooting message about `Application not found` error  
This requires one adds the info about the organization with the  `--org` param